### PR TITLE
B038 Updating Mentions

### DIFF
--- a/app/dtos.py
+++ b/app/dtos.py
@@ -286,11 +286,30 @@ token_output_list_dto = api.model(
     },
 )
 
-login_input_dto = api.model('LoginInput', {
-    'email': fields.String(required=True, description="The email of the user"),
-    'password': fields.String(required=True, description="The password of the user"),
-})
+login_input_dto = api.model(
+    "LoginInput",
+    {
+        "email": fields.String(required=True, description="The email of the user"),
+        "password": fields.String(
+            required=True, description="The password of the user"
+        ),
+    },
+)
 
-login_output_dto = api.model('LoginOutput', {
-    'token': fields.String(required=True, description="The JWT token for authenticated user"),
-})
+login_output_dto = api.model(
+    "LoginOutput",
+    {
+        "token": fields.String(
+            required=True, description="The JWT token for authenticated user"
+        ),
+    },
+)
+
+mention_update_input_dto = api.model(
+    "UpdateMentionInput",
+    {
+        "tag": fields.String,
+        "token_ids": fields.List(fields.Integer),
+        "entity_id": fields.Integer,
+    },
+)

--- a/app/repositories/mention_repository.py
+++ b/app/repositories/mention_repository.py
@@ -18,12 +18,12 @@ class MentionRepository(BaseRepository):
                 Mention.entity_id,
                 TokenMention.token_id,
             )
-            .outerjoin(TokenMention,Mention.id == TokenMention.mention_id)
+            .outerjoin(TokenMention, Mention.id == TokenMention.mention_id)
             .filter(
                 (Mention.document_edit_id == document_edit_id)
                 & (
-                        Mention.document_recommendation_id.is_(None)
-                        | Mention.isShownRecommendation.is_(True)
+                    Mention.document_recommendation_id.is_(None)
+                    | Mention.isShownRecommendation.is_(True)
                 )
             )
             .all()
@@ -70,8 +70,7 @@ class MentionRepository(BaseRepository):
 
     def set_entity_id_to_null(self, entity_id):
         mentions = (
-            self.db_session.query(Mention)
-            .filter(Mention.entity_id == entity_id)
+            self.db_session.query(Mention).filter(Mention.entity_id == entity_id)
         ).all()
 
         for mention in mentions:
@@ -84,5 +83,17 @@ class MentionRepository(BaseRepository):
         if not isinstance(entity_id, int) or entity_id <= 0:
             raise ValueError("Invalid entity ID. It must be a positive integer.")
 
-        return self.db_session.query(Mention).filter(Mention.entity_id == entity_id).all()
+        return (
+            self.db_session.query(Mention).filter(Mention.entity_id == entity_id).all()
+        )
 
+    def update_mention(self, mention_id, tag, entity_id):
+        mention = self.get_mention_by_id(mention_id)
+        if tag:
+            mention.tag = tag
+        if entity_id:
+            mention.entity_id = entity_id
+        elif entity_id == 0:
+            mention.entity_id = None
+        super().store_object(mention)
+        return mention

--- a/app/repositories/token_repository.py
+++ b/app/repositories/token_repository.py
@@ -1,5 +1,5 @@
 from app.db import db
-from app.models import Token
+from app.models import Token, DocumentEdit
 from app.repositories.base_repository import BaseRepository
 
 
@@ -17,3 +17,12 @@ class TokenRepository(BaseRepository):
 
     def get_tokens_by_document(self, document_id):
         return db.session.query(Token).filter(Token.document_id == document_id).all()
+
+    def get_tokens_by_document_edit(self, document_edit_id):
+        return (
+            db.session.query(Token)
+            .select_from(DocumentEdit)
+            .join(Token, Token.document_id == DocumentEdit.document_id)
+            .filter(DocumentEdit.id == document_edit_id)
+            .all()
+        )

--- a/app/repositories/user_repository.py
+++ b/app/repositories/user_repository.py
@@ -1,3 +1,5 @@
+from werkzeug.exceptions import NotFound
+
 from app.models import UserTeam, DocumentEdit, User, Team, Project, Document
 from app.repositories.base_repository import BaseRepository
 from app.db import db
@@ -12,14 +14,12 @@ class UserRepository(BaseRepository):
         )
 
     def get_user_by_email(self, mail):
-        return (
-            db.session.query(User)
-            .filter(User.email == mail)
-            .first()
-        )
+        return db.session.query(User).filter(User.email == mail).first()
 
     def get_user_by_document_edit_id(self, document_edit_id):
         document_edit = db.session.query(DocumentEdit).get(document_edit_id)
+        if document_edit is None:
+            raise NotFound("Document Edit not found")
         return document_edit.user_id
 
     def get_user_by_username(self, username):

--- a/app/routes/mention_routes.py
+++ b/app/routes/mention_routes.py
@@ -3,7 +3,12 @@ from flask_jwt_extended import jwt_required, verify_jwt_in_request, get_jwt_iden
 from werkzeug.exceptions import BadRequest
 from flask_restx import Resource, Namespace
 from app.services.mention_services import mention_service
-from app.dtos import mention_output_dto, mention_output_list_dto, mention_input_dto
+from app.dtos import (
+    mention_output_dto,
+    mention_output_list_dto,
+    mention_input_dto,
+    mention_update_input_dto,
+)
 
 ns = Namespace("mentions", description="Mention related operations")
 
@@ -51,4 +56,15 @@ class MentionDeletionResource(Resource):
     @ns.doc(description="Delete a mention and its related relations")
     def delete(self, mention_id):
         response = self.service.delete_mention(mention_id)
+        return response
+
+    @jwt_required()
+    @ns.expect(mention_update_input_dto)
+    @ns.marshal_with(mention_output_dto)
+    def patch(self, mention_id):
+        data = request.get_json()
+        tag = data.get("tag")
+        token_ids = data.get("token_ids")
+        entity_id = data.get("entity_id")
+        response = self.service.update_mention(mention_id, tag, token_ids, entity_id)
         return response

--- a/app/services/entity_service.py
+++ b/app/services/entity_service.py
@@ -1,11 +1,11 @@
 from app.repositories.entity_repository import EntityRepository
-from werkzeug.exceptions import BadRequest, NotFound
+from werkzeug.exceptions import BadRequest, NotFound, Forbidden
 from app.services.user_service import UserService, user_service
 from app.repositories.mention_repository import MentionRepository
 
 
 class EntityService:
-    def __init__(self, entity_repository,mention_repository):
+    def __init__(self, entity_repository, mention_repository):
         self.__entity_repository = entity_repository
         self.__mention_repository = mention_repository
 
@@ -38,11 +38,11 @@ class EntityService:
         if entity.document_edit_id is None:
             raise BadRequest("Entity must belong to a valid document_edit_id.")
 
-        #logged_in_user_id = user_service.get_logged_in_user_id()
-        #document_edit_user_id = user_service.get_user_by_document_edit_id(entity.document_edit_id)
+        # logged_in_user_id = user_service.get_logged_in_user_id()
+        # document_edit_user_id = user_service.get_user_by_document_edit_id(entity.document_edit_id)
 
-       # if logged_in_user_id != document_edit_user_id:
-           # raise NotFound("The logged in user does not belong to this document.")
+        # if logged_in_user_id != document_edit_user_id:
+        # raise NotFound("The logged in user does not belong to this document.")
 
         mentions_updated = self.__mention_repository.set_entity_id_to_null(entity_id)
         if mentions_updated > 0:
@@ -51,5 +51,12 @@ class EntityService:
         self.__entity_repository.delete_entity_by_id(entity_id)
         return {"message": "Entity deleted successfully."}
 
+    def check_entity_in_document_edit(self, entity_id, document_edit_id):
+        entity = self.__entity_repository.get_entity_by_id(entity_id)
+        if not entity:
+            raise BadRequest("Entity does not exist")
+        if entity.document_edit_id != document_edit_id:
+            raise Forbidden("Entity does not belong to this document")
 
-entity_service = EntityService(EntityRepository(),MentionRepository())
+
+entity_service = EntityService(EntityRepository(), MentionRepository())

--- a/app/services/mention_services.py
+++ b/app/services/mention_services.py
@@ -200,16 +200,15 @@ class MentionService:
                 self.token_mention_service.create_token_mention(token_id, mention_id)
 
         # Delete entity if it is empty after update, id = 0: clear entity_id of mention
-        if (
-            entity_id is not None
-            and mention.entity_id
-            and entity_id != mention.entity_id
-        ):
+        if entity_id is not None:
             if entity_id != 0:
                 self.entity_service.check_entity_in_document_edit(
                     entity_id, mention.document_edit_id
                 )
-            self.delete_entity_if_only_consists_mention(mention_id, mention.entity_id)
+            if mention.entity_id and entity_id != mention.entity_id:
+                self.delete_entity_if_only_consists_mention(
+                    mention_id, mention.entity_id
+                )
 
         updated_mention = self.__mention_repository.update_mention(
             mention_id, tag, entity_id

--- a/app/services/mention_services.py
+++ b/app/services/mention_services.py
@@ -3,6 +3,7 @@ from werkzeug.exceptions import BadRequest, NotFound, Conflict, Unauthorized
 
 from app.repositories.mention_repository import MentionRepository
 from app.services.project_service import ProjectService, project_service
+from app.services.token_service import TokenService, token_service
 from app.services.user_service import UserService, user_service
 from app.services.relation_services import RelationService, relation_service
 from app.services.entity_service import EntityService, entity_service
@@ -20,6 +21,7 @@ class MentionService:
     project_service: ProjectService
     relation_service: RelationService
     entity_service: EntityService
+    token_service: TokenService
 
     def __init__(
         self,
@@ -29,6 +31,7 @@ class MentionService:
         project_service,
         relation_service,
         entity_service,
+        token_service,
     ):
         self.__mention_repository = mention_repository
         self.token_mention_service = token_mention_service
@@ -36,6 +39,7 @@ class MentionService:
         self.project_service = project_service
         self.relation_service = relation_service
         self.entity_service = entity_service
+        self.token_service = token_service
 
     def get_mentions_by_document_edit(self, document_edit_id):
         if not isinstance(document_edit_id, int) or document_edit_id <= 0:
@@ -47,7 +51,9 @@ class MentionService:
         if current_user_id != str(user_id):
             raise Unauthorized("You are not authorized to perform this action.")
 
-        results = self.__mention_repository.get_mentions_with_tokens_by_document_edit(document_edit_id)
+        results = self.__mention_repository.get_mentions_with_tokens_by_document_edit(
+            document_edit_id
+        )
 
         mentions_dict = {}
         for row in results:
@@ -70,30 +76,21 @@ class MentionService:
 
         # check if user is allowed to access this document edit
         logged_in_user_id = user_service.get_logged_in_user_id()
-        document_edit_user_id = user_service.get_user_by_document_edit_id(
-            data["document_edit_id"]
+        self.user_service.check_user_document_edit_accessible(
+            logged_in_user_id, data["document_edit_id"]
         )
 
-        if logged_in_user_id != document_edit_user_id:
-            raise NotFound("The logged in user does not belong to this document.")
+        # Check that tokens belong to this document
+        self.token_service.check_tokens_in_document_edit(
+            data["token_ids"], data["document_edit_id"]
+        )
 
         # check duplicates
-        mentions = self.__mention_repository.get_mentions_with_tokens_by_document_edit(
-            data["document_edit_id"]
+        duplicate_token_mention = self.check_token_in_mention(
+            data["document_edit_id"], data["token_ids"]
         )
-        if len(mentions) > 0:
-
-            token_ids = data["token_ids"]
-            mention_ids = []
-            for mention in mentions:
-                mention_ids.append(mention.id)
-
-            duplicate_token_mention = token_mention_service.get_token_mention(
-                token_ids, mention_ids
-            )
-
-            if len(duplicate_token_mention) > 0:
-                raise Conflict("Token mention already exists.")
+        if len(duplicate_token_mention) > 0:
+            raise Conflict("Token mention already exists.")
 
         # save mention
         mention = self.__mention_repository.create_mention(
@@ -142,33 +139,110 @@ class MentionService:
             )
 
         # logged_in_user_id = user_service.get_logged_in_user_id()
-        # document_edit_user_id = user_service.get_user_by_document_edit_id(mention.document_edit_id)
-
-        # if logged_in_user_id != document_edit_user_id:
-        # raise NotFound("The logged in user does not belong to this document.")
+        # self.user_service.check_user_document_edit_accessible(user_id, mention.document_edit_id)
 
         related_relations = self.relation_service.get_relations_by_mention(mention_id)
         for relation in related_relations:
             self.relation_service.delete_relation_by_id(relation.id)
 
         self.token_mention_service.delete_token_mentions_by_mention_id(mention_id)
-
-        if mention.entity_id is not None:
-            mentions_with_entity = self.__mention_repository.get_mentions_by_entity_id(
-                mention.entity_id
-            )
-
-            if (
-                len(mentions_with_entity) == 1
-                and mentions_with_entity[0].id == mention_id
-            ):
-                self.entity_service.delete_entity(mention.entity_id)
+        self.delete_entity_if_only_consists_mention(mention_id, mention.entity_id)
 
         deleted = self.__mention_repository.delete_mention_by_id(mention_id)
         if not deleted:
             raise NotFound("Mention not found during deletion.")
 
         return {"message": "OK"}
+
+    def delete_entity_if_only_consists_mention(self, mention_id, entity_id):
+        if entity_id is not None:
+            mentions_with_entity = self.__mention_repository.get_mentions_by_entity_id(
+                entity_id
+            )
+
+            if (
+                len(mentions_with_entity) == 1
+                and mentions_with_entity[0].id == mention_id
+            ):
+                self.entity_service.delete_entity(entity_id)
+
+    def update_mention(self, mention_id, tag, token_ids, entity_id):
+        # Check that mention exists
+        mention = self.__mention_repository.get_mention_by_id(mention_id)
+        if not mention:
+            raise NotFound("Mention not found.")
+
+        if mention.document_recommendation_id:
+            raise BadRequest("You cannot update a recommendation")
+
+        # Check that user owns this document edit
+        user_id = get_jwt_identity()  # self.user_service.get_logged_in_user_id()
+        self.user_service.check_user_document_edit_accessible(
+            user_id, mention.document_edit_id
+        )
+
+        if token_ids:
+            # Check that tokens belong to this document
+            self.token_service.check_tokens_in_document_edit(
+                token_ids, mention.document_edit_id
+            )
+            # Check that tokens are not used in other mention
+            duplicate_tokens = self.check_token_in_mention(
+                mention.document_edit_id, token_ids
+            )
+            for duplicate_token in duplicate_tokens:
+                if duplicate_token.mention_id != mention_id:
+                    raise Conflict("Token already part of mention")
+
+            # Update token mentions
+            self.token_mention_service.delete_token_mentions_by_mention_id(mention_id)
+            for token_id in token_ids:
+                self.token_mention_service.create_token_mention(token_id, mention_id)
+
+        # Delete entity if it is empty after update, id = 0: clear entity_id of mention
+        if (
+            entity_id is not None
+            and mention.entity_id
+            and entity_id != mention.entity_id
+        ):
+            if entity_id != 0:
+                self.entity_service.check_entity_in_document_edit(
+                    entity_id, mention.document_edit_id
+                )
+            self.delete_entity_if_only_consists_mention(mention_id, mention.entity_id)
+
+        updated_mention = self.__mention_repository.update_mention(
+            mention_id, tag, entity_id
+        )
+        token_mentions = self.token_mention_service.get_token_mentions_by_mention_id(
+            mention_id
+        )
+        return {
+            "id": updated_mention.id,
+            "tag": updated_mention.tag,
+            "is_shown_recommendation": updated_mention.isShownRecommendation,
+            "document_edit_id": updated_mention.document_edit_id,
+            "document_recommendation_id": updated_mention.document_recommendation_id,
+            "entity_id": updated_mention.entity_id,
+            "tokens": [token_mention.token_id for token_mention in token_mentions],
+        }
+
+    def check_token_in_mention(self, document_edit_id, token_ids):
+        # check duplicates
+        mentions = self.__mention_repository.get_mentions_with_tokens_by_document_edit(
+            document_edit_id
+        )
+        if len(mentions) > 0:
+
+            mention_ids = []
+            for mention in mentions:
+                mention_ids.append(mention.mention_id)
+
+            duplicate_token_mention = token_mention_service.get_token_mention(
+                token_ids, mention_ids
+            )
+            return duplicate_token_mention
+        return []
 
 
 mention_service = MentionService(
@@ -178,4 +252,5 @@ mention_service = MentionService(
     project_service,
     relation_service,
     entity_service,
+    token_service,
 )

--- a/app/services/token_service.py
+++ b/app/services/token_service.py
@@ -56,5 +56,14 @@ class TokenService:
             ]
         }
 
+    def check_tokens_in_document_edit(self, token_ids, document_edit_id):
+        document_tokens = self.__token_repository.get_tokens_by_document_edit(
+            document_edit_id
+        )
+        document_token_ids = [document_token.id for document_token in document_tokens]
+        for token_id in token_ids:
+            if token_id not in document_token_ids:
+                raise BadRequest("Tokens do not belong to this document.")
+
 
 token_service = TokenService(TokenRepository(), user_service)

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -1,12 +1,11 @@
 from datetime import timedelta
 from app.config import Config
 from flask import session
-from werkzeug.exceptions import BadRequest, Forbidden, Unauthorized
+from werkzeug.exceptions import BadRequest, Forbidden, Unauthorized, NotFound
 from werkzeug.security import generate_password_hash, check_password_hash
 from app.repositories.user_repository import UserRepository
 from app.repositories.user_team_repository import UserTeamRepository
 from flask_jwt_extended import create_access_token
-
 
 
 class UserService:
@@ -66,6 +65,12 @@ class UserService:
         ):
             raise Forbidden("You cannot access this document")
 
+    def check_user_document_edit_accessible(self, user_id, document_edit_id):
+        document_edit_user_id = self.get_user_by_document_edit_id(document_edit_id)
+
+        if int(user_id) != int(document_edit_user_id):
+            raise NotFound("The logged in user does not belong to this document.")
+
     def login(self, email, password):
         try:
             user = self.get_user_by_email(email)
@@ -74,9 +79,11 @@ class UserService:
 
             if not check_password_hash(user.password, password):
                 raise Unauthorized("Invalid email or password")
-            user_id_str=str(user.id)
+            user_id_str = str(user.id)
             expires_delta = timedelta(seconds=Config.JWT_ACCESS_TOKEN_EXPIRES)
-            token = create_access_token(identity=user_id_str, expires_delta=expires_delta)
+            token = create_access_token(
+                identity=user_id_str, expires_delta=expires_delta
+            )
             return {"token": token}
         except Exception as e:
             raise


### PR DESCRIPTION
- Added endpoint for updating mentions
- Added checks if input tokens and entities belong to same document
- To clear entity_id in mention, id=0 can be used
- Also added check for valid token in create-function
- Restructured service functions into smaller sub-functions for reuse